### PR TITLE
Fixed bugs causing problems in Ascend Canvas

### DIFF
--- a/gaphas/decorators.py
+++ b/gaphas/decorators.py
@@ -117,7 +117,7 @@ class async(object):
             if GObject.main_depth() == 0:
                 return func(*args, **kwargs)
             elif not self.single:
-                def async_wrapper(_):
+                def async_wrapper(*x):
                     if DEBUG_ASYNC: print 'async:', func, args, kwargs
                     func(*args, **kwargs)
                 source(async_wrapper).attach()
@@ -128,7 +128,7 @@ class async(object):
                     if getattr(holder, async_id):
                         return
                 except AttributeError, e:
-                    def async_wrapper(_):
+                    def async_wrapper(*x):
                         if DEBUG_ASYNC: print 'async:', func, args, kwargs
                         try:
                             func(*args, **kwargs)

--- a/gaphas/tool.py
+++ b/gaphas/tool.py
@@ -503,8 +503,7 @@ class PanTool(Tool):
         if not event.get_state()[1] & PAN_MASK == PAN_VALUE:
             return False
         view = self.view
-        direction = event.direction
-        gdk = Gtk.gdk
+        direction = event.scroll.direction
         if direction == Gdk.ScrollDirection.LEFT:
             view._matrix.translate(self.speed/view._matrix[0], 0)
         elif direction == Gdk.ScrollDirection.RIGHT:
@@ -578,10 +577,10 @@ class ZoomTool(Tool):
             view = self.view
             sx = view._matrix[0]
             sy = view._matrix[3]
-            ox = (view._matrix[4] - event.x) / sx
-            oy = (view._matrix[5] - event.y) / sy
+            ox = (view._matrix[4] - event.scroll.x) / sx
+            oy = (view._matrix[5] - event.scroll.y) / sy
             factor = 0.9
-            if event.direction == Gdk.ScrollDirection.UP:    
+            if event.scroll.direction == Gdk.ScrollDirection.UP:
                 factor = 1. / factor
             view._matrix.translate(-ox, -oy)
             view._matrix.scale(factor, factor)

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -534,7 +534,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
         self._hadjustment_handler_id = None
         self._vadjustment_handler_id = None
 
-        self.emit('set-scroll-adjustments', hadjustment, vadjustment)
+        self._set_scroll_adjustments(None, None)
 
         self._set_tool(DefaultTool())
         


### PR DESCRIPTION
I fixed three bugs which I noticed working under Ascend project. Explanation:
1. When you use gnome 2, async_wrapper() takes no arguments, in gnome 3 async_wrapper() takes exactly one argument. In this case argument isn't needed.
2. In Gtk3: x, y, direction etc. are accessible from "event type" objects.
3. The ::set-scroll-adjustments signal on GtkWidget has been replaced by the GtkScrollable interface (reference: http://www.lanedo.com/users/cgarnacho/gtk3-doc/ch25s02.html)